### PR TITLE
Add remoteToken option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ There are several configuration settings supported:
 | `setupIcon`           | No       | The ICO file to use as the icon for the generated Setup.exe |
 | `noMsi`               | No       | Should Squirrel.Windows create an MSI installer? |
 | `remoteReleases`      | No       | A URL to your existing updates. If given, these will be downloaded to create delta updates |
+| `remoteToken`      | No       | Authentication token for remote updates |
 | `log`                 | No       | By default, logging at info and above goes to console. The value `false` will stop all logging. An object with the functions `error`, `warn`, `info`, `debug` will use those for logging. |
 
 ## Sign your installer or else bad things will happen

--- a/index.coffee
+++ b/index.coffee
@@ -117,7 +117,7 @@ module.exports.build = (config, done) ->
       args = ['-u', remoteReleases, '-r', outputDirectory.path()]
 
       if remoteToken?
-        args.push '-t' remoteToken
+        args.push '-t', remoteToken
 
       if useMono
         args.unshift(cmd)

--- a/index.coffee
+++ b/index.coffee
@@ -66,7 +66,7 @@ module.exports.build = (config, done) ->
   loadingGif = config.loadingGif ? resourcesDirectory.path('install-spinner.gif')
   loadingGif = jetpack.path(loadingGif)
 
-  {certificateFile, certificatePassword, remoteReleases, signWithParams} = config
+  {certificateFile, certificatePassword, remoteReleases, remoteToken, signWithParams} = config
 
   asarFile = appDirectory.path('resources', 'app.asar')
   if jetpack.exists(asarFile)
@@ -115,6 +115,9 @@ module.exports.build = (config, done) ->
     if remoteReleases?
       cmd = vendorDirectory.path('SyncReleases.exe')
       args = ['-u', remoteReleases, '-r', outputDirectory.path()]
+
+      if remoteToken?
+        args.push '-t' remoteToken
 
       if useMono
         args.unshift(cmd)


### PR DESCRIPTION
An authentication token option `-t` is supported by SyncReleases.exe

It is necessary for connecting to private repos.

Thanks for making this repo!  I've been using a custom port of `grunt-electron-installer` and this is the only difference from the code that I have in production.