### PR TITLE
Docs: electron-winstaller uses promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ var electronInstaller = require('electron-winstaller');
 Then do a build like so..
 
 ```js
-electronInstaller.createWindowsInstaller({
+resultPromise = electronInstaller.createWindowsInstaller({
     appDirectory: '/tmp/build/my-app-64',
     outputDirectory: '/tmp/build/installer64',
     authors: 'My App Inc.',
     exe: 'myapp.exe'
-  }, done);
+  });
+  
+resultPromise.then(() => console.log("It worked!"), (e) => console.log(`No dice: ${e.message}`));
 ```
 
 After running you will have an `.nupkg`, a


### PR DESCRIPTION
The Docs say that electron-winstaller uses callbacks, but it actually returns a Promise