### PR TITLE
Fixed typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ export async function createWindowsInstaller(options) {
     if (typeof(metadata.author) === 'string') {
       metadata.authors = metadata.author;
     } else {
-      metadata.authors = (metadata.authors || {}).name || '';
+      metadata.authors = (metadata.author || {}).name || '';
     }
   }
 


### PR DESCRIPTION
I believe that the changed line was trying to fetch the name from "author":{"name":"blah", "email":"blah" etc}. 
