### PR TITLE
options should override app meta data, not the other way round

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ export async function createWindowsInstaller(options) {
     title: appMetadata.productName || appMetadata.name
   };
 
-  let metadata = _.assign({}, appMetadata, options, defaults);
+  let metadata = _.defaults({}, options, defaults, appMetadata);
 
   if (!metadata.authors) {
     if (typeof(metadata.author) === 'string') {


### PR DESCRIPTION
I had a empty description in my package.json and a description in the options but it didn't work.
It says this in the readme `Defaults to the description field from your app's package.json file when unspecified.` so I guess appMetaData should not override options...