### PR TITLE
Use latest npm on AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
   - "4.1"
 
+branches:
+  only:
+    - master
+
 before_install:
   - sudo add-apt-repository ppa:ubuntu-wine/ppa -y
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ branches:
   only:
     - master
 
+cache:
+  directories:
+    - node_modules
+
 before_install:
   - sudo add-apt-repository ppa:ubuntu-wine/ppa -y
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Electron Installer
 
-[![Build status](https://ci.appveyor.com/api/projects/status/nxhep80va4d7afjb?svg=true)](https://ci.appveyor.com/project/kevinsawicki/windows-installer)
-
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/nxhep80va4d7afjb/branch/master?svg=true)](https://ci.appveyor.com/project/kevinsawicki/windows-installer/branch/master)
+[![Travis CI Build Status](https://travis-ci.org/electronjs/windows-installer.svg?branch=master)](https://travis-ci.org/electronjs/windows-installer)
 
 NPM module that builds Windows installers for
 [Electron](https://github.com/atom/electron) apps using
@@ -30,7 +30,7 @@ resultPromise = electronInstaller.createWindowsInstaller({
     authors: 'My App Inc.',
     exe: 'myapp.exe'
   });
-  
+
 resultPromise.then(() => console.log("It worked!"), (e) => console.log(`No dice: ${e.message}`));
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,12 @@ install:
   - npm install npm
   - .\node_modules\.bin\npm install
 
-
 build: off
 
 test_script:
   - node --version
   - .\node_modules\.bin\npm --version
   - .\node_modules\.bin\npm test
+
+cache:
+  - node_modules -> package.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,9 @@
+branches:
+  only:
+    - master
+
+skip_tags: true
+
 init:
   - git config --global core.autocrlf input
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ init:
 
 environment:
   matrix:
-    - nodejs_version: 4.2.6
+    - nodejs_version: 4.3.2
 
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,13 @@ environment:
 
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
-  - npm install
+  - npm install npm
+  - .\node_modules\.bin\npm install
+
 
 build: off
 
 test_script:
   - node --version
-  - npm --version
-  - npm test
+  - .\node_modules\.bin\npm --version
+  - .\node_modules\.bin\npm test


### PR DESCRIPTION
Attempting to fix `EPERM` errors like: https://ci.appveyor.com/project/kevinsawicki/windows-installer/build/1.0.85 by using npm 3 on AppVeyor.

Seems related to https://github.com/npm/npm/issues/9696 and http://help.appveyor.com/discussions/problems/3147-error-eperm-operation-not-permitted-rename-on-npm-install

Also adds `node_modules/` caching to both builds and only building master branch and pull requests by default to prevent double statuses for Travis and AppVeyor.