### PR TITLE
Fix copying resources and locales to installer

### DIFF
--- a/template.nuspec
+++ b/template.nuspec
@@ -12,14 +12,14 @@
     <copyright><%- copyright %></copyright>
   </metadata>
   <files>
-    <file src="locales\**" target="lib\net45\locales" />
-    <file src="resources\**" target="lib\net45\resources" />
-    <file src="*.bin" target="lib\net45" />
-    <file src="*.dll" target="lib\net45" />
-    <file src="*.pak" target="lib\net45" />
-    <file src="Update.exe" target="lib\net45\squirrel.exe" />
-    <file src="icudtl.dat" target="lib\net45\icudtl.dat" />
-    <file src="LICENSE" target="lib\net45\LICENSE" />
-    <file src="<%- exe %>" target="lib\net45\<%- exe %>" />
+    <file src="locales/**" target="lib/net45/locales" />
+    <file src="resources/**" target="lib/net45/resources" />
+    <file src="*.bin" target="lib/net45" />
+    <file src="*.dll" target="lib/net45" />
+    <file src="*.pak" target="lib/net45" />
+    <file src="Update.exe" target="lib/net45/squirrel.exe" />
+    <file src="icudtl.dat" target="lib/net45/icudtl.dat" />
+    <file src="LICENSE" target="lib/net45/LICENSE" />
+    <file src="<%- exe %>" target="lib/net45/<%- exe %>" />
   </files>
 </package>


### PR DESCRIPTION
Use forward slashes instead of backslashes in .nuspec. I suppose that backslashes in path spec have to be quoted with another backslash, but historically one can use forward slashes in paths while opening files programmatically. The safe way is to use forward slashes in .nuspec and nuget.exe understands them perfectly.