### PR TITLE
use babel es2015-node4 — we can require nodejs 4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["stage-0", "es2015"],
-  "plugins": ["transform-runtime"]
-}

--- a/package.json
+++ b/package.json
@@ -14,25 +14,43 @@
     "test": "eslint spec && mocha --compilers js:babel-register ./spec/*.js"
   },
   "dependencies": {
-    "asar": "~0.8.0",
-    "babel-polyfill": "^6.3.0",
-    "babel-runtime": "^6.5.0",
+    "asar": "~0.10.0",
+    "bluebird": "^3.3.4",
     "debug": "^2.2.0",
-    "fs-extra": "^0.26.5",
-    "fs-jetpack": "^0.7.1",
-    "lodash": "^4.0.0",
-    "temp": "^0.8.1"
+    "fs-extra": "^0.26.7",
+    "fs-jetpack": "^0.7.2",
+    "lodash": "^4.6.1",
+    "temp": "^0.8.3"
   },
   "devDependencies": {
-    "babel-cli": "^6.4.5",
-    "babel-eslint": "^4.1.7",
-    "babel-plugin-transform-runtime": "^6.5.2",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
-    "babel-register": "^6.3.13",
-    "chai": "^3.4.1",
+    "babel-cli": "^6.6.5",
+    "babel-eslint": "^6.0.0-beta.6",
+    "babel-plugin-transform-async-to-module-method": "^6.7.0",
+    "babel-plugin-transform-runtime": "^6.6.0",
+    "babel-preset-es2015-node4": "^2.0.3",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.7.2",
+    "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
-    "eslint": "^1.10.3",
-    "mocha": "^2.3.4"
+    "eslint": "^2.4.0",
+    "mocha": "^2.4.5"
+  },
+  "engines": {
+    "node": ">=0.4.0"
+  },
+  "babel": {
+    "presets": [
+      "stage-0",
+      "es2015-node4"
+    ],
+    "plugins": [
+      [
+        "transform-async-to-module-method",
+        {
+          "module": "bluebird",
+          "method": "coroutine"
+        }
+      ]
+    ]
   }
 }

--- a/spec/support.js
+++ b/spec/support.js
@@ -1,5 +1,3 @@
-import '../src/babel-maybefill';
-
 let chai = require("chai");
 let chaiAsPromised = require("chai-as-promised");
 

--- a/src/babel-maybefill.js
+++ b/src/babel-maybefill.js
@@ -1,3 +1,0 @@
-if (!('regeneratorRuntime' in global)) {
-  require('babel-polyfill');
-}


### PR DESCRIPTION
I think, it is ok to support only NodeJS 4+.